### PR TITLE
Use new TERM_CHILD logic for sending TERM signals to child worker proces...

### DIFF
--- a/lib/robot-controller/bluepill.rb
+++ b/lib/robot-controller/bluepill.rb
@@ -26,6 +26,8 @@ Bluepill.application File.basename(File.dirname(File.dirname(WORKDIR))),
 
         # use environment for these resque variables
         process.environment = {
+          'TERM_CHILD' => '1', # TERM, KILL, USR1 sent to worker process if running
+          'RESQUE_TERM_TIMEOUT' => '10.0', # seconds to wait before sending KILL after TERM
           'QUEUES' => queues,
           'ROBOT_ENVIRONMENT' => robot_environment,
           'INTERVAL' => '5'


### PR DESCRIPTION
...ses. Fixes #20.

There's new logic for how Resque handles signals:
- QUIT: sets a `shutdown` flag that triggers a `break` on the next worker loop
- TERM or KILL: sends TERM signal to active worker process, waits n seconds, then sends KILL

the old logic always sends a KILL signal to the active worker process.
